### PR TITLE
Source: Added CFAST new input file format

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -584,9 +584,14 @@ Module cfast_arrays
   Use global_constants
   Implicit none
 
+  ! HEAD namelist data
+  Integer :: cfast_version
+  Character(128) :: cfast_title
+
   Real(kind=rk), Dimension(:,:), Allocatable :: cfast_target_xyz, cfast_comp_xyz, cfast_target_ior
   Real(kind=rk), Dimension(:), Allocatable :: cfast_matl_epsilon, cfast_target_epsilon
   Character(len=chr20), Dimension(:), Allocatable :: cfast_target_name, cfast_target_matl, cfast_matl_name
+  Character(len=chr20), Dimension(:), Allocatable :: cfast_target_compname, cfast_comp_name
   Integer, Dimension(:), Allocatable :: cfast_target_comp
 
 End Module cfast_arrays


### PR DESCRIPTION
Now fds2fem can read the new CFAST .in file format, which is
similar to FDS namelist input file format.

Also the CHID_w.csv file is checked, if the normal or validation
output option is used. This is only needed if the transfer quantity
is adiabatic surface temperature.